### PR TITLE
Add placeholder DICOM test and GitHub Actions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,27 @@
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pydicom
+    - name: Test with pytest
+      run: |
+        pytest
+

--- a/README
+++ b/README
@@ -1,1 +1,13 @@
 Nothing much just training a radiology model to read dicom files.
+
+## Running Tests
+
+1. Install dependencies:
+   ```bash
+   pip install pytest pydicom
+   ```
+2. Run the tests with:
+   ```bash
+   pytest
+   ```
+

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -1,0 +1,8 @@
+import pydicom
+from pydicom.data import get_testdata_file
+
+def test_dicom_loading():
+    filename = get_testdata_file("CT_small.dcm")
+    ds = pydicom.dcmread(filename)
+    assert ds.PatientName is not None
+


### PR DESCRIPTION
## Summary
- add initial DICOM test using pydicom sample data
- run tests via GitHub Actions with pytest
- explain how to execute the test suite locally in the README

## Testing
- `pip install pytest pydicom`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432f4167cc8322bcaa12aedb7306e8